### PR TITLE
Change User Role Logic to Enforce Default Role as "User"

### DIFF
--- a/src/Controllers/UsersController.cs
+++ b/src/Controllers/UsersController.cs
@@ -24,7 +24,7 @@ public class UsersController : ControllerBase
         {
             Name = user.Name,
             Email = user.Email,
-            Role = user.Role
+            Role = "user"
         };
         
         var password = PasswordGenerator.Generate(25);

--- a/src/Models/Users.cs
+++ b/src/Models/Users.cs
@@ -6,8 +6,8 @@ public class Users
     public string Name { get; set; }
     public string Email { get; set; }
     public string PasswordHash { get; set; }
-    public string Role { get; set; }
+    public string Role { get; set; } = "user";
     
-    // Empty Lists (for now) => Change it afterwards
+    // Empty Lists (for now) => Change it later
     public ICollection<EntryExitLogs> EntryExitLogs { get; set; } = new List<EntryExitLogs>();  
 }

--- a/src/ViewModels/ResultViewModel.cs
+++ b/src/ViewModels/ResultViewModel.cs
@@ -1,0 +1,36 @@
+namespace AccessTrackAPI.ViewModels;
+
+// Classe genérica para padronizar a resposta da API
+public class ResultViewModel<T>
+{
+    // Construtor que recebe tanto os dados quanto uma lista de erros
+    public ResultViewModel(T data, List<string> errors)
+    {
+        Data = data;
+        Errors = errors;
+    }
+
+    // Construtor que recebe apenas os dados (sem erros)
+    public ResultViewModel(T data)
+    {
+        Data = data;
+    }
+    
+    // Construtor que recebe apenas uma lista de erros (sem dados)
+    public ResultViewModel(List<string> errors)
+    {
+        Errors = errors;
+    }
+    
+    // Construtor que recebe um único erro e adiciona à lista de erros
+    public ResultViewModel(string error)
+    {
+        Errors.Add(error);
+    }
+    
+    // Propriedade para armazenar os dados da resposta
+    public T Data { get; private set; }
+    
+    // Propriedade para armazenar os erros da resposta (inicializa como uma lista vazia)
+    public List<string> Errors { get; private set; } = new(); // O C# consegue inferir que é uma List<string>
+}


### PR DESCRIPTION
Currently, the user registration logic allows the role field to be set without restrictions, which can lead to inconsistencies in the system.

Changes:
- Set default role to "user" in the `Users` model.
- Update registration logic to enforce the "user" role.
- Add validation to prevent unauthorized role assignment.